### PR TITLE
Implement #2

### DIFF
--- a/app/bot.py
+++ b/app/bot.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
+import os
 import string
-import logging
 import asyncio
 from aiohttp import web
 from aiotg import Bot, Chat, InlineQuery
@@ -84,8 +84,8 @@ if __name__ == '__main__':
         loop.run_until_complete(bot.delete_webhook())
         bot.run(debug=True)
     else:
-        logging.basicConfig(filename='log.txt', filemode='w')
         webhook_future = bot.set_webhook("https://{}:{}/{}/{}".format(HOST, SERVER_PORT, NAME, TOKEN))
         loop.run_until_complete(webhook_future)
         app = bot.create_webhook_app('/{}/{}'.format(NAME, TOKEN), loop)
-        web.run_app(app, host='127.0.0.1', port=APP_PORT)
+        os.umask(0o137)    # rw-r----- for the unix socket
+        web.run_app(app, path=UNIX_SOCKET)

--- a/examples/config.py
+++ b/examples/config.py
@@ -6,10 +6,9 @@ OWNER_ID = 12345678
 REPO_URL = "github.com/username/textUtilsBot"
 
 HOST = "bots.example.org"
-APP_PORT = 8080         # A port for a local server, which the application establishes.
-SERVER_PORT = 8443      # A port on a front-end web server.
+SERVER_PORT = 8443                        # A port on a front-end web server.
+UNIX_SOCKET = "/tmp/textUtilsBot.sock"    # A Unix domain socket to communicate with that web server.
 
 # Set to 'False' for production use.
-# Determines whether polling or web hooks will be used.
-# Also determines what will be used for logging messages: either stderr or a file.
+# Besides the level of verbosity, determines whether polling or webhooks will be used.
 DEBUG = True

--- a/examples/nginx-textUtilsBot.conf
+++ b/examples/nginx-textUtilsBot.conf
@@ -12,9 +12,8 @@ server {
     #access_log /dev/null;
     #error_log /home/username/logs/nginx/textUtilsBot.err.log;
 
-    # Ensure the path and port are consistent with the NAME and APP_PORT constants from 'app/config.py' respectively.
+    # Ensure the paths are consistent with the NAME and UNIX_SOCKET constants from 'app/config.py'.
     location /textUtilsBot/ {
-        # Set the port to APP_PORT.
-        proxy_pass http://127.0.0.1:8080;
+        proxy_pass http://unix:/tmp/textUtilsBot.sock;
     }
 }

--- a/examples/supervisord-textUtilsBot.conf
+++ b/examples/supervisord-textUtilsBot.conf
@@ -1,8 +1,8 @@
 [program:textUtilsBot]
-command = /home/username/textUtilsBot/start.sh
-directory=/home/username/textUtilsBot/
-user=username
-autostart=true
-autorestart=true
-stderr_logfile=/home/username/logs/supervisord/textUtilsBot.err.log
-stdout_logfile=/home/username/logs/supervisord/textUtilsBot.out.log
+command        = /home/username/textUtilsBot/start.sh
+directory      = /home/username/textUtilsBot/
+user           = www-data
+autostart      = true
+autorestart    = true
+stderr_logfile = /home/username/logs/supervisord/textUtilsBot.err.log
+stdout_logfile = /home/username/logs/supervisord/textUtilsBot.out.log

--- a/init.sh
+++ b/init.sh
@@ -11,6 +11,8 @@ echo
 
 echo "Creating a configuration file..."
 cp examples/config.py app/config.py
+sudo chgrp www-data app/config.py
+chmod o-r app/config.py
 echo
 
 echo "Done. Don't forget to replace fake values in 'app/config.py' with your actual ones."


### PR DESCRIPTION
Replace a TCP socket, used for communication between front-end and
back-end servers, with a Unix domain socket to potentially improve
performance a bit.

However, this enhancement introduces small but additional complexity
related to file permissions management. From now, if you prefer to use
`nginx` as a front-end server, it's necessary to run the bot on behalf of
`www-data`. Otherwise, `nginx` won't be able to write data to the socket
file.

Note that there won't be any capabilities of migration to another OS
afterward. Only Unix-like operating systems.