### PR TITLE
Сancellation of async tasks at exit and token reveal prevention

### DIFF
--- a/app/bot.py
+++ b/app/bot.py
@@ -102,8 +102,8 @@ if __name__ == '__main__':
 
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
-    for x in async_tasks:
-        loop.create_task(x)
+    tasks = [loop.create_task(t) for t in async_tasks]
+    bot.on_cleanup(lambda: [t.cancel() for t in tasks])
 
     if DEBUG:
         loop.run_until_complete(bot.delete_webhook())

--- a/app/bot.py
+++ b/app/bot.py
@@ -109,8 +109,8 @@ if __name__ == '__main__':
         loop.run_until_complete(bot.delete_webhook())
         bot.run(debug=True)
     else:
-        webhook_future = bot.set_webhook("https://{}:{}/{}/{}".format(HOST, SERVER_PORT, NAME, TOKEN))
+        webhook_future = bot.set_webhook(f"https://{HOST}:{SERVER_PORT}/{NAME}")
         loop.run_until_complete(webhook_future)
-        app = bot.create_webhook_app('/{}/{}'.format(NAME, TOKEN), loop)
+        app = bot.create_webhook_app(f"/{NAME}", loop)
         os.umask(0o137)    # rw-r----- for the unix socket
         web.run_app(app, path=UNIX_SOCKET, loop=loop)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/kozalosev/aiotg@feature/chosen_inline_result#egg=aiotg
+git+https://github.com/kozalosev/aiotg@master-patched#egg=aiotg
 aiohttp==3.8.4
 klocmod==0.3.0
 requests==2.28.2


### PR DESCRIPTION
\+ make use of secret_token parameter of the setWebhook
See: https://github.com/kozalosev/aiotg/tree/feature/cleanup-and-security

Since we're now using the `secret_token` parameter of the `setWebhook` method,
we're able to get rid of token usage in the URL. This helps us to prevent
reveal of the token in logs and proxies (like Cloudflare) infrastructure.